### PR TITLE
Enable running benchmark targets as Python modules

### DIFF
--- a/pybm/commands/run.py
+++ b/pybm/commands/run.py
@@ -47,14 +47,6 @@ class RunCommand(CLICommand):
                                  dest="run_all",
                                  help="Run specified benchmarks in all "
                                       "existing pybm environments.")
-        self.parser.add_argument("--filter",
-                                 type=str,
-                                 default=None,
-                                 dest="benchmark_filter",
-                                 help="Regex filter to selectively run "
-                                      "benchmarks inside the target files. "
-                                      "Only benchmarks matching the given "
-                                      "filter will be run.")
         self.parser.add_argument("--repetitions",
                                  type=int,
                                  default=5,
@@ -65,6 +57,22 @@ class RunCommand(CLICommand):
                                       "statistical significance of "
                                       "performance differences between "
                                       "different environments.")
+        self.parser.add_argument("-m",
+                                 action="store_true",
+                                 default=False,
+                                 dest="run_as_module",
+                                 help="Run benchmark targets as modules. "
+                                      "This is the preferred option if you "
+                                      "are benchmarking code outside of a "
+                                      "package.")
+        self.parser.add_argument("--filter",
+                                 type=str,
+                                 default=None,
+                                 dest="benchmark_filter",
+                                 help="Regex filter to selectively run "
+                                      "benchmarks inside the target files. "
+                                      "Only benchmarks matching the given "
+                                      "filter will be run.")
         self.parser.add_argument("--context",
                                  action="append",
                                  default=None,
@@ -149,6 +157,7 @@ class RunCommand(CLICommand):
                         benchmark=benchmark,
                         environment=environment,
                         repetitions=options.repetitions,
+                        run_as_module=options.run_as_module,
                         benchmark_filter=options.benchmark_filter,
                         benchmark_context=options.benchmark_context)
                     # TODO: Switch this to a general IO Connector later
@@ -161,10 +170,10 @@ class RunCommand(CLICommand):
                             json.dump(json.loads(data), res)
             else:
                 msg = f"Benchmark selector {benchmark_path!r} did not match " \
-                      f"any directories or Python files in environment " \
+                      f"any directory or Python files in environment " \
                       f"{environment.name!r}."
                 if runner.fail_fast:
-                    error_msg = "Aborted benchmarking run because fast " \
+                    error_msg = "Aborted benchmark run because fast " \
                                 "failure mode was enabled."
                     raise PybmError("\n".join([msg, error_msg]))
                 else:

--- a/pybm/util/imports.py
+++ b/pybm/util/imports.py
@@ -15,6 +15,12 @@ def module_exists(module_name: str):
     return spec is not None
 
 
+def convert_to_module(file: Union[str, Path]) -> str:
+    fp = Path(file)
+    file_str = (fp.parent / fp.stem).as_posix()
+    return file_str.replace("/", ".")
+
+
 def import_module_from_source(source_path: Union[str, Path]) -> ModuleType:
     # TODO: Use path and extension to come up with a unique name here
     p = Path(source_path)
@@ -23,8 +29,8 @@ def import_module_from_source(source_path: Union[str, Path]) -> ModuleType:
     elif p.suffix != ".py":
         raise PybmError(f"Source path {source_path} is not a Python file.")
 
-    # strip away .py extension and cast to module syntax
-    py_name = p.with_suffix("").as_posix().replace("/", ".")
+    # strip away .py extension and convert to module syntax
+    py_name = convert_to_module(p)
     if py_name in sys.modules:
         # return loaded module
         return sys.modules[py_name]


### PR DESCRIPTION
Fixes #1.

Previously, the benchmark runner's `dispatch` method dispatched all
subprocesses with the `python benchmark_file.py [options]` syntax. This
unfortunately leads to a lot of trouble when benchmarking code that is not
contained in a package, i.e. cannot be discovered using `sys.path`. Instead
of requiring users to write a setup.py for each of their target packages,
this commit enables running the targets as modules instead.

To do this, the user simply uses the `-m` switch during `pybm run`, similarly
to how he would invoke a file as a module with the standard Python interpreter.