### PR TITLE
Add pre-commit workflow to GitHub CI

### DIFF
--- a/.github/ci.yaml
+++ b/.github/ci.yaml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Run pre-commit hooks
+        uses: pre-commit/action@v2.0.3


### PR DESCRIPTION
This commit contains a GitHub Action for running pre-commit hooks
inside a GitHub CI workflow. Currently, it is set to activate on PRs
and pushes to master only.